### PR TITLE
Use neurodebian for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
-FROM ubuntu:14.04
-RUN sudo apt-get update -qq && apt-get install -y python python-pip python-dev build-essential software-properties-common
-RUN sudo add-apt-repository ppa:openjdk-r/ppa && apt-get update -qq && apt-get install -y openjdk-8-jdk
+FROM neurodebian:stretch-non-free
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq && apt-get install -y python python-pip python-dev build-essential software-properties-common
+RUN add-apt-repository ppa:openjdk-r/ppa && apt-get update -qq && apt-get install -y openjdk-8-jdk
 RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
 ENV JAVA_HOME /docker-java-home
 ENV JCC_JDK /docker-java-home
 
-RUN sudo apt-get install -y git python-pip python-dev wget jcc
+RUN apt-get install -y git python-pip python-dev wget jcc
 
-RUN useradd -g root --create-home --shell /bin/bash neuro \
-    && usermod -aG sudo neuro \
-    && usermod -aG users neuro
+#RUN useradd -g root --create-home --shell /bin/bash neuro \
+    #&& usermod -aG users neuro
+
+RUN useradd --no-user-group --create-home --shell /bin/bash neuro
 
 RUN pip install --upgrade wheel JCC twine urllib3 pip 
 RUN mkdir /home/neuro/nighres
@@ -18,7 +21,7 @@ COPY nighres /home/neuro/nighres/nighres
 RUN cd /home/neuro/nighres && ./build.sh
 RUN cd /home/neuro/nighres && pip install .
 
-RUN pip install jupyter nilearn sklearn nose matplotlib
+RUN pip install jupyter nilearn sklearn nose matplotlib scipy
 COPY docker/jupyter_notebook_config.py /etc/jupyter/
 
 RUN mkdir /home/neuro/notebooks


### PR DESCRIPTION
For me the DockerFile stopped working because of an older version of the SSL libraries in ubuntun 14.04. I updated the DockerFile a little bit to use a newer version of Ubuntu. Specifically, Neuroebian, which is also used by many other neuroDockers.