### PR TITLE
fix failing docs by using sphinx-gallery master

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
 sphinx
 pillow
 matplotlib
-sphinx-gallery
+git+https://github.com/sphinx-gallery/sphinx-gallery
 sphinx-rtd-theme
 scipy
 sklearn


### PR DESCRIPTION
The docs on readthedocs started failing to build due an [incompatibility of sphinx-gallery and sphinx](https://github.com/sphinx-gallery/sphinx-gallery/pull/352#issuecomment-367090938).  We can circumvent the issue for now by installing sphinx-gallery from master, until the fix provided there is released