### PR TITLE
bugfix: fetch repo before checking out new release during build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,6 +46,7 @@ test -f "${python_include_path}/Python.h" || fatal 'This script requires python 
 # Get cbstools git clone
 test -d cbstools-public && (
     cd cbstools-public
+	git fetch
 	git checkout $release
 	git pull
 	cd ..
@@ -104,6 +105,7 @@ cd ..
 # Get imcntk git clone
 test -d imcn-imaging && (
     cd imcn-imaging
+	git fetch
 	git checkout $release
 	git pull
 	cd ..


### PR DESCRIPTION
Hi, trying to update nighres I realized there is a bug in build.sh.
If you work in an old build directory and just do "git pull" and "./build.sh" the script tries to checkout the current release of cbstools-public and imcn-imaging without updating the (probably) outdated repositories. To avoid errors the build script should update the repositories before checkout.

I think the "git pull" after the checkout is not necessary and can actually be removed after applying my patch. I did not test that, tough.