### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+nibabel
+psutil
+antspyx
+jcc


### PR DESCRIPTION
Since JCC is required to build the java code underneath, jcc is included.

https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/